### PR TITLE
Support multiple attachments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,5 +5,6 @@ import { NativeModules } from 'react-native'
 // NativeModules.ShareExtension.close()
 export default {
   data: () => NativeModules.ReactNativeShareExtension.data(),
+  dataMulti: () => NativeModules.ReactNativeShareExtension.dataMulti(),
   close: () => NativeModules.ReactNativeShareExtension.close()
 }


### PR DESCRIPTION
This change adds support for multiple attachments, allowing callers
to create a share extensions that can select more than one item to
share.

This change adds a dataMulti() function to the share extension, which
instead of returning a single item returns an array of items, the original
data() function is unchanged, so this change is backwards compatible.

The change only adds this support to iOS, not Android.