### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ the setup requires a little bit more work. I will try to describe as detail as p
 ```objective-c
 #import <Foundation/Foundation.h>
 #import "ReactNativeShareExtension.h"
-#import "RCTBundleURLProvider.h"
-#import "RCTRootView.h"
+#import "React/RCTBundleURLProvider.h"
+#import "React/RCTRootView.h"
 
 @interface MyShareEx : ReactNativeShareExtension
 @end


### PR DESCRIPTION
https://stackoverflow.com/a/41722530/224707

> As of React Native 0.40 (see release notes), native code on iOS must refer to headers out of the react namespace. Previously the following would work:

>     #import "RCTBundleURLProvider.h"
> But now all headers have been moved:

>     #import <React/RCTBundleURLProvider.h>