### PR TITLE
Add iOS device troubleshooting section to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ the setup requires a little bit more work. I will try to describe as detail as p
 ```objective-c
 #import <Foundation/Foundation.h>
 #import "ReactNativeShareExtension.h"
-#import "React/RCTBundleURLProvider.h"
-#import "React/RCTRootView.h"
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLog.h>
 
 @interface MyShareEx : ReactNativeShareExtension
 @end
@@ -135,6 +136,10 @@ RCT_EXPORT_MODULE();
                                                initialProperties:nil
                                                    launchOptions:nil];
   rootView.backgroundColor = nil;
+
+  // Uncomment for console output in Xcode console for release mode on device:
+  // RCTSetLogThreshold(RCTLogLevelInfo - 1);
+
   return rootView;
 }
 
@@ -425,9 +430,90 @@ Note that while the above will prevent many apps from wrongly sharing using your
 
 For reference about `NSExtensionActivationRule` checkout [Apple's docs](https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW8)
 
+# App and app extension bundles
+
+The app and app extension bundles can be shared or separated. Separating bundles allows for a minimal footprint for both app and app extension.
+
+#### plist key legend
+
+`BundleEntryFilename` - react-native index or shared index filename.
+
+`BundleSkipped` - Skips bundling when true.
+
+`BundleCopied` - Copies bundle instead of building when true. (Note: Should be set as true for share extension plist only when bundles are shared.)
+
+`BundleForced` - Forces bundling when true.
+
+### Shared bundles
+
+The app extension target builds pre-loaded bundle and is copied to the app target.
+
+#### app plist values
+
+`BundleEntryFilename` = 'index.js'
+
+`BundleSkipped` = true
+
+`BundleCopied` = true
+
+#### app target's "Bundle React Native code and images" phase
+```
+export NODE_BINARY=node
+../bin/react-native-xcode.sh
+```
+
+#### appShareExtension plist values
+
+`BundleEntryFilename` = 'index.js'
+
+`BundleForced` = true
+
+#### appShareExtension target's "Bundle React Native code and images" phase
+```
+cd ../
+npm run cp-native-assets
+cd ios/
+export NODE_BINARY=node
+../bin/react-native-xcode.sh
+```
+
+### Separated bundles
+
+The app extension and app targets build their own unique bundles.
+
+NSNotificationCenter will kill app extensions that are unable to free memory resources when receiving low memory warnings. Also, shared bundles introduce library/pod dependencies that aren't needed by both apps. Configuring separate bundles via Xcode requires customizing react-native-xcode.sh; a quick example customization can be found in the bin directory. Update the path to the packager in both the app and app extension target's "Bundle React Native code and images" Build Phases.
+
+Build time can be halved while debugging by disabling the bundle for whichever target you aren't debugging (app or app ex).
+
+#### app plist values
+
+`BundleEntryFilename` = 'index.js'
+
+#### app target's "Bundle React Native code and images" phase
+```
+export NODE_BINARY=node
+#export ENTRY_FILENAME=index
+../bin/react-native-xcode.sh
+```
+
+#### appShareExtension plist values
+
+`BundleEntryFilename` = 'share.index.js'
+
+`BundleForced` = true
+
+#### appShareExtension target's "Bundle React Native code and images" phase
+```
+cd ../
+npm run cp-native-assets
+cd ios/
+export NODE_BINARY=node
+../bin/react-native-xcode.sh
+```
+
 # Troubleshooting on iOS devices
 
-Using the iOS Simulator and remote react-native debugger to develop the extension can hide issues that won't appear until running on device. If you're experiencing issues running the extension on iOS devices, examine the device log for any obvious errors. In the absence of errors, make sure the Xcode target is set to debug mode (which will allow console.log statements to appear in the device log), then examine your JS code for initialization errors.
+Using the iOS Simulator and remote react-native debugger to develop the extension can hide issues that won't occur until testing on device. If you're experiencing issues running the extension on iOS devices, examine the Xcode console or device log for any obvious errors. If the Xcode console isn't receiving console output, ensure that the OS_ACTIVITY_MODE=disable environment var isn't enabled for the active scheme (see https://github.com/facebook/react-native/issues/10027). OS_ACTIVITY_MODE will hide device logging in the Xcode console, so its use is only advisable for iOS Simulator. For release mode, in order to view console output and see all output in the syslog, uncomment the `RCTSetLogThreshold(RCTLogLevelInfo - 1);` statement in your MyShareEx class.
 
 1. If you're using react-native latest, error boundaries might help with JS errors. Another option is to catch render exceptions or test for errors, then render that output with something like a Text component. As long as your share app initializes, you should be able to see yellowbox/redbox errors. If you're not seeing them, you likely have an initialization issue.
 2. Disable bundling on the main target when debugging the extension target, it's not needed when you're not working with the main app.

--- a/README.md
+++ b/README.md
@@ -425,6 +425,14 @@ Note that while the above will prevent many apps from wrongly sharing using your
 
 For reference about `NSExtensionActivationRule` checkout [Apple's docs](https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW8)
 
+# Troubleshooting on iOS devices
+
+Using the iOS Simulator and remote react-native debugger to develop the extension can hide issues that won't appear until running on device. If you're experiencing issues running the extension on iOS devices, examine the device log for any obvious errors. In the absence of errors, make sure the Xcode target is set to debug mode (which will allow console.log statements to appear in the device log), then examine your JS code for initialization errors.
+
+1. If you're using react-native latest, error boundaries might help with JS errors. Another option is to catch render exceptions or test for errors, then render that output with something like a Text component. As long as your share app initializes, you should be able to see yellowbox/redbox errors. If you're not seeing them, you likely have an initialization issue.
+2. Disable bundling on the main target when debugging the extension target, it's not needed when you're not working with the main app.
+3. [Enable breaking on exceptions](http://blog.manbolo.com/2012/01/23/xcode-tips-1-break-on-exceptions). This is helpful if there are any exceptions in the extension itself; perhaps most useful if you've customized the native module.
+
 # Final note
 
 I have used `react-native-modalbox` module to handle the showing and hiding share extension which makes the experience more enjoyable for the user.

--- a/bin/react-native-xcode.sh
+++ b/bin/react-native-xcode.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+# Bundle React Native app's code and image assets.
+# This script is supposed to be invoked as part of Xcode build process
+# and relies on environment variables (including PWD) set by Xcode
+
+DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
+MAIN_BUNDLE="main.jsbundle"
+BUNDLE_FILE="$DEST/$MAIN_BUNDLE"
+TMP_PATH="/tmp"
+PLISTBUDDY='/usr/libexec/PlistBuddy'
+PLIST=$TARGET_BUILD_DIR/$INFOPLIST_PATH
+
+[ -z "$SKIP_BUNDLING" ] && SKIP_BUNDLING=$($PLISTBUDDY -c "Print :BundleSkipped" "${PLIST}")
+[ -z "$CP_BUNDLING" ] && CP_BUNDLING=$($PLISTBUDDY -c "Print :BundleCopied" "${PLIST}")
+
+if [[ "$SKIP_BUNDLING" && $SKIP_BUNDLING == "true" ]]; then
+  echo "SKIP_BUNDLING enabled; skipping."
+  if [[ "$CP_BUNDLING" && $CP_BUNDLING == "true" ]]; then
+    TMP_BUNDLE="$TMP_PATH/$MAIN_BUNDLE"
+    echo "CP_BUNDLING enabled; copying $TMP_BUNDLE to $DEST/"
+    if [ -f "$TMP_BUNDLE" ]; then
+      cp "$TMP_PATH/$MAIN_BUNDLE"* "$DEST/"
+    else
+      echo "CP_BUNDLING $TMP_BUNDLE does not exist!"
+    fi
+  fi
+  exit 0;
+fi
+
+[ -z "$IS_DEV" ] && IS_DEV=$($PLISTBUDDY -c "Print :BundleDev" "${PLIST}")
+[ -z "$FORCE_BUNDLING" ] && FORCE_BUNDLING=$($PLISTBUDDY -c "Print :BundleForced" "${PLIST}")
+
+if [ -z "$IS_DEV" ]; then
+  case "$CONFIGURATION" in
+    *Debug*)
+      if [[ "$PLATFORM_NAME" == *simulator ]]; then
+        if [[ "$FORCE_BUNDLING" && $FORCE_BUNDLING == "true" ]]; then
+          echo "FORCE_BUNDLING enabled; continuing to bundle."
+        else
+          echo "Skipping bundling in Debug for the Simulator (since the packager bundles for you). Use the FORCE_BUNDLING env flag or BundleForced plist key to change this behavior."
+          exit 0;
+        fi
+      else
+        echo "Bundling for physical device. Use the SKIP_BUNDLING flag to change this behavior."
+      fi
+
+      DEV=true
+      ;;
+    "")
+      echo "$0 must be invoked by Xcode"
+      exit 1
+      ;;
+    *)
+      DEV=false
+      ;;
+  esac
+else
+  if [[ "$PLATFORM_NAME" == *simulator ]]; then
+    if [[ "$FORCE_BUNDLING" && $FORCE_BUNDLING == "true" ]]; then
+      echo "FORCE_BUNDLING enabled; continuing to bundle."
+    else
+      echo "Skipping bundling in Debug for the Simulator (since the packager bundles for you). Use the FORCE_BUNDLING flag to change this behavior."
+      exit 0;
+    fi
+  else
+    echo "Bundling for physical device. Use the SKIP_BUNDLING flag to change this behavior."
+  fi
+  DEV=$IS_DEV
+fi
+
+# Path to react-native folder inside node_modules
+# REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Path to react-native folder inside src/native/utils/bin
+REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../node_modules/react-native" && pwd)"
+echo "REACT_NATIVE_DIR: $REACT_NATIVE_DIR"
+
+# Xcode project file for React Native apps is located in ios/ subfolder
+cd "${REACT_NATIVE_DIR}"/../..
+
+# Define NVM_DIR and source the nvm.sh setup script
+[ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
+
+# Define default ENTRY_FILENAME
+[ -z "$ENTRY_FILENAME" ] && ENTRY_FILENAME=$($PLISTBUDDY -c "Print :BundleEntryFilename" "${PLIST}")
+[ -z "$ENTRY_FILENAME" ] && ENTRY_FILENAME="index.js"
+echo "ENTRY_FILENAME: $ENTRY_FILENAME"
+
+js_file_type=.js
+ios_file_type=.ios.js
+ios_file_name="${ENTRY_FILENAME/$js_file_type/$ios_file_type}"
+
+# Define entry file
+if [[ -s $ios_file_name ]]; then
+  ENTRY_FILE=${1:-$ios_file_name}
+else
+  ENTRY_FILE=${1:-$ENTRY_FILENAME}
+fi
+
+if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+  . "$HOME/.nvm/nvm.sh"
+elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
+  . "$(brew --prefix nvm)/nvm.sh"
+fi
+
+# Set up the nodenv node version manager if present
+if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
+  eval "$("$HOME/.nodenv/bin/nodenv" init -)"
+fi
+
+[ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
+
+[ -z "$CLI_PATH" ] && export CLI_PATH="$REACT_NATIVE_DIR/local-cli/cli.js"
+
+nodejs_not_found()
+{
+  echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle" >&2
+  echo "If you have non-standard nodejs installation, select your project in Xcode," >&2
+  echo "find 'Build Phases' - 'Bundle React Native code and images'" >&2
+  echo "and change NODE_BINARY to absolute path to your node executable" >&2
+  echo "(you can find it by invoking 'which node' in the terminal)" >&2
+  exit 2
+}
+
+type $NODE_BINARY >/dev/null 2>&1 || nodejs_not_found
+
+# Print commands before executing them (useful for troubleshooting)
+set -x
+# DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
+
+if [[ "$CONFIGURATION" = "Debug" && ! "$PLATFORM_NAME" == *simulator ]]; then
+  BUNDLE_SERVER=$($PLISTBUDDY -c "Print :BundleServer" "${PLIST}")
+  echo "BUNDLE_SERVER: ${BUNDLE_SERVER}"
+  if [ -z "$BUNDLE_SERVER" ]; then
+    IP=$(ipconfig getifaddr en0)
+    if [ -z "$IP" ]; then
+      IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | cut -d\   -f2  | awk 'NR==1{print $1}')
+    fi
+  else
+    IP=$BUNDLE_SERVER
+  fi
+
+  if [ -z ${DISABLE_XIP+x} ]; then
+    IP="$IP.xip.io"
+  fi
+
+  $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:localhost:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
+  $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:$IP:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
+  echo "$IP" > "$DEST/ip.txt"
+fi
+
+$NODE_BINARY "$CLI_PATH" bundle \
+  --entry-file "$ENTRY_FILE" \
+  --platform ios \
+  --dev $DEV \
+  --reset-cache \
+  --bundle-output "$BUNDLE_FILE" \
+  --assets-dest "$DEST"
+
+if [[ $DEV != true && ! -f "$BUNDLE_FILE" ]]; then
+  echo "error: File $BUNDLE_FILE does not exist. This must be a bug with" >&2
+  echo "React Native, please report it here: https://github.com/facebook/react-native/issues"
+  exit 2
+else
+  cp "$BUNDLE_FILE"* $TMP_PATH
+  if [[ $DEV == "true" ]]; then
+    if nc -w 5 -z localhost 8081 ; then
+      if ! curl -s "http://localhost:8081/status" | grep -q "packager-status:running"; then
+        echo "Port 8081 already in use, packager is either not running or not running correctly"
+        exit 0
+      fi
+    else
+      open "$REACT_NATIVE_DIR/scripts/launchPackager.command" || echo "Can't start packager automatically"
+    fi
+  fi
+fi


### PR DESCRIPTION
Troubleshooting the app extension on device can be quite challenging.

- [x] Update README.
  - [x] Add iOS troubleshooting section.
    - [x] Add guidance for separating app/extension bundles.