### PR TITLE
Remove stopping provider finder if find one

### DIFF
--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -72,13 +72,10 @@ RCT_REMAP_METHOD(data,
         [attachments enumerateObjectsUsingBlock:^(NSItemProvider *provider, NSUInteger idx, BOOL *stop) {
             if([provider hasItemConformingToTypeIdentifier:URL_IDENTIFIER]) {
                 urlProvider = provider;
-                *stop = YES;
             } else if ([provider hasItemConformingToTypeIdentifier:TEXT_IDENTIFIER]){
                 textProvider = provider;
-                *stop = YES;
             } else if ([provider hasItemConformingToTypeIdentifier:IMAGE_IDENTIFIER]){
                 imageProvider = provider;
-                *stop = YES;
             }
         }];
 


### PR DESCRIPTION
Hi! This package is very useful and thanks for your work!
I've tried it with sharing from app apple.news and was confused when began sharing.
Apple.news app shares two providers - string `title` and url `url`, but in extension takes only first matching - if string encounters first then the `data` prop will be the string, if it image so the `data` will be the image and so on. I'm very foolish in objective-c and don't know, how it could be reached to take the all providers from the app sharing you from and pass them to the javascript side.
Because of it I remove stopping the attachments iterator when provider found. It will be better if someone who knows objective-c could update this code to reach the goal.
How do you think, @alinz ?