### PR TITLE
#100 - Properly exit extension on close

### DIFF
--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -39,6 +39,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(close) {
     [extensionContext completeRequestReturningItems:nil
                                   completionHandler:nil];
+    exit(0);
 }
 
 


### PR DESCRIPTION
This change was provided by @EnochL in #100.

It fixes the issue of the share extension not exiting properly on close in iOS 11.3.1

@alinz Please review.