### PR TITLE
Support New Google Photos API & MMS

### DIFF
--- a/android/src/main/java/com/alinz/parkerdan/shareextension/RealPathUtil.java
+++ b/android/src/main/java/com/alinz/parkerdan/shareextension/RealPathUtil.java
@@ -143,7 +143,7 @@ public class RealPathUtil {
         if (isGoogleOldPhotosUri(uri)) {
             // return http path, then download file.
             return uri.getLastPathSegment();
-        } else if (isGoogleNewPhotosUri(uri)) {
+        } else if (isGoogleNewPhotosUri(uri) || isMMSFile(uri)) {
             // copy from uri. context.getContentResolver().openInputStream(uri);
             return copyFile(context, uri);
         }
@@ -163,6 +163,10 @@ public class RealPathUtil {
  public static boolean isGoogleNewPhotosUri(Uri uri) {
     return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
  }
+
+ public static boolean isMMSFile(Uri uri) {
+    return "com.android.mms.file".equals(uri.getAuthority());
+}
 
  private static String copyFile(Context context, Uri uri) {
 


### PR DESCRIPTION
1) Supports the new Google Photos use of `"com.google.android.apps.photos.contentprovider"`.

2) Supports MMS format.

3) Supports displaying remote files by creating a copy of the file locally and storing it using a unique id.

This code is a modified version of https://gist.github.com/ZeroBrain/b93a1cbd889b672e8b06.