### PR TITLE
Restores proper image handling for iOS

### DIFF
--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -68,7 +68,6 @@ RCT_REMAP_METHOD(data,
 }
 
 - (void)extractDataFromContext:(NSExtensionContext *)context withCallback:(void(^)(NSString *value, NSString* contentType, NSException *exception))callback {
-    
     @try {
         NSExtensionItem *item = [context.inputItems firstObject];
         NSArray *attachments = item.attachments;
@@ -100,31 +99,10 @@ RCT_REMAP_METHOD(data,
             }];
         } else if (imageProvider) {
             [imageProvider loadItemForTypeIdentifier:IMAGE_IDENTIFIER options:nil completionHandler:^(id<NSSecureCoding> item, NSError *error) {
-                
-                /**
-                 * Save the image to NSTemporaryDirectory(), which cleans itself tri-daily.
-                 * This is necessary as the iOS 11 screenshot editor gives us a UIImage, while
-                 * sharing from Photos and similar apps gives us a URL
-                 * Therefore the solution is to save a UIImage, either way, and return the local path to that temp UIImage
-                 * This path will be sent to React Native and can be processed and accessed RN side.
-                **/
-                
-                UIImage *sharedImage;
-                NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"RNSE_TEMP_IMG"];
-                NSString *fullPath = [filePath stringByAppendingPathExtension:@"png"];
-                
-                if ([(NSObject *)item isKindOfClass:[UIImage class]]){
-                    sharedImage = (UIImage *)item;
-                }else if ([(NSObject *)item isKindOfClass:[NSURL class]]){
-                    NSURL* url = (NSURL *)item;
-                    NSData *data = [NSData dataWithContentsOfURL:url];
-                    sharedImage = [UIImage imageWithData:data];
-                }
-                
-                [UIImagePNGRepresentation(sharedImage) writeToFile:fullPath atomically:YES];
-                
+                NSURL *url = (NSURL *)item;
+
                 if(callback) {
-                    callback(fullPath, [fullPath pathExtension], nil);
+                    callback([url absoluteString], [[[url absoluteString] pathExtension] lowercaseString], nil);
                 }
             }];
         } else if (textProvider) {
@@ -147,7 +125,5 @@ RCT_REMAP_METHOD(data,
         }
     }
 }
-
-
 
 @end


### PR DESCRIPTION
Reverts changes in https://github.com/alinz/react-native-share-extension/commit/1e98f58991a892fd941a809f9564fb5181693ba0.

Changes in that PR cause inability to use image data for fetch requests. I personally find that I am unable to upload images from the share extension if the changes linked are included. This PR gets things working again.

@brenwarwcdg Please review your work. I'm not strong in Objective-C, but there appears to be an issue. It seems in these changes, images are assumed to be `png` for iOS. https://github.com/alinz/react-native-share-extension/commit/5540d951bb16b92a95bf855998afe8344de0e70c#diff-cd365a662ae840f4beb6a01a1c8ffa1fR106