### PR TITLE
Reuse RCTBridge for the share view. Fixes #64

### DIFF
--- a/ios/ReactNativeShareExtension.h
+++ b/ios/ReactNativeShareExtension.h
@@ -2,5 +2,19 @@
 #import "React/RCTBridgeModule.h"
 
 @interface ReactNativeShareExtension : UIViewController<RCTBridgeModule>
+
+/**
+ * @deprecated This method should not be used unless you are creating
+ * a shared bridge inside of shareView.
+ * @note Please use @code shareViewWithRCTBridge @endcode instead.
+ */
 - (UIView*) shareView;
+
+/**
+ * Create a shareView using a common RCTBridge. The RCTBridge is reused
+ * for each launch of the share sheet. This allows the share sheet to
+ * free its resources in between launches.
+ */
+- (UIView*) shareViewWithRCTBridge:(RCTBridge*)sharedBridge;
+
 @end

--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -8,6 +8,10 @@
 
 NSExtensionContext* extensionContext;
 
+// Save a copy of the RCTBridge to reuse. Creating a new bridge
+// each time this saves mempory.
+RCTBridge *sharedBridge;
+
 @implementation ReactNativeShareExtension {
     NSTimer *autoTimer;
     NSString* type;
@@ -15,6 +19,10 @@ NSExtensionContext* extensionContext;
 }
 
 - (UIView*) shareView {
+    return nil;
+}
+
+- (UIView*) shareViewWithRCTBridge:(RCTBridge*)sharedBridge {
     return nil;
 }
 
@@ -27,7 +35,19 @@ RCT_EXPORT_MODULE();
     //variable extensionContext. in this way, both exported method can touch extensionContext
     extensionContext = self.extensionContext;
 
-    UIView *rootView = [self shareView];
+    if (sharedBridge == nil) {
+        sharedBridge = [[RCTBridge alloc] initWithBundleURL:jsCodeLocation
+                                             moduleProvider:nil
+                                              launchOptions:nil];
+    }
+
+    UIView *rootView = [self shareViewWithRCTBridge:sharedBridge];
+
+    if (rootView == nil) {
+        // Fallback to the previous version if shareViewWithRCTBridge isn't implemented.
+        rootView = [self shareView];
+    }
+
     if (rootView.backgroundColor == nil) {
         rootView.backgroundColor = [[UIColor alloc] initWithRed:1 green:1 blue:1 alpha:0.1];
     }
@@ -39,8 +59,13 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(close) {
     [extensionContext completeRequestReturningItems:nil
                                   completionHandler:nil];
-}
 
+    // Set the view to nil so it gets cleaned up.
+    self.view = nil;
+
+    [sharedBridge invalidate];
+    sharedBridge = nil;
+}
 
 
 RCT_EXPORT_METHOD(openURL:(NSString *)url) {


### PR DESCRIPTION
I think this is the general idea for fixing memory issues inside of the share view. This still needs to be tested. I didn't see instructions for running react-native-share-extension independently for testing, so I am putting together a mini project to verify this works.

As implemented, this should be backwards compatible.