### PR TITLE
Fixes yellow warning "requiresMainQueueSetup" in iOS simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # React Native Share Extension
-This fork includes some changes to the [original alinz/react-native-share-extension](https://github.com/alinz/react-native-share-extension).
+This fork includes some changes to the [original alinz/react-native-share-extension](https://github.com/alinz/react-native-share-extension) for my specific use case; getting URL's and document HTML from a page.
 
 ## Changes:
 - Uses a `ExtensionPreprocessingJS` (GetDocumentData.js) to get the: url, title and html from a webpage

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # React Native Share Extension
+This fork includes some changes to the [original alinz/react-native-share-extension](https://github.com/alinz/react-native-share-extension).
 
-Diff with: https://github.com/alinz/react-native-share-extension
-- Uses a ExtensionPreprocessingJS to get the: url, title and html from a webpage using `dataProvider` in `/react-native-share-extension/ios/ReactNativeShareExtension.m`
-- Prefer the URL if no webpage is loaded
-- Info.plist changes
+## Changes:
+- Uses a `ExtensionPreprocessingJS` (GetDocumentData.js) to get the: url, title and html from a webpage using
+- Changes to `ReactNativeShareExtension` to get the data from ExtensionPreprocessingJS
+- Prefers the URL if no webpage is loaded
+- Info.plist changes so it uses `ExtensionPreprocessingJS`
 
 
-/ios/ShareExtension/GetDocumentData.js
+**/ios/ShareExtension/GetDocumentData.js**
+
 (make sure you add this file through xcode, or else it does not get included in the build)
 
 ```javascript
@@ -36,7 +39,7 @@ var ExtensionPreprocessingJS = new GetDocumentData;
 
 ```
 
-/ios/ShareExtension/Info.plist
+**/ios/ShareExtension/Info.plist**
 ```
 <key>NSExtension</key>
 <dict>

--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 This fork includes some changes to the [original alinz/react-native-share-extension](https://github.com/alinz/react-native-share-extension).
 
 ## Changes:
-- Uses a `ExtensionPreprocessingJS` (GetDocumentData.js) to get the: url, title and html from a webpage using
-- Changes to `ReactNativeShareExtension` to get the data from ExtensionPreprocessingJS
+- Uses a `ExtensionPreprocessingJS` (GetDocumentData.js) to get the: url, title and html from a webpage
+- Changes to `ReactNativeShareExtension.m` to get the data from the `ExtensionPreprocessingJS` file, see `DATA_IDENTIFIER` in `ReactNativeShareExtension.m` 
 - Prefers the URL if no webpage is loaded
+- Removed getting an image from the attachment, our use case does not include images
 - Info.plist changes so it uses `ExtensionPreprocessingJS`
-
+- Use `/ios/GetDocumentData.js` and place it in `/ios/YourShareExtension/GetDocumentData.js`
 
 **/ios/ShareExtension/GetDocumentData.js**
 
-(make sure you add this file through xcode, or else it does not get included in the build)
+Use `/ios/GetDocumentData.js` and place it in `/ios/YourShareExtension/GetDocumentData.js`. Make sure you add this file through xcode, or else it does not get included in the build)
 
 ```javascript
 // prettier-ignore

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # React Native Share Extension
 
+Diff with: https://github.com/alinz/react-native-share-extension
+- Uses a ExtensionPreprocessingJS to get the: url, title and html from a webpage
+- Prefer the URL, if not webpage is loaded
+
 This is a helper module which brings react native as an engine to drive share extension for your app.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,8 +1,69 @@
 # React Native Share Extension
 
 Diff with: https://github.com/alinz/react-native-share-extension
-- Uses a ExtensionPreprocessingJS to get the: url, title and html from a webpage
-- Prefer the URL, if not webpage is loaded
+- Uses a ExtensionPreprocessingJS to get the: url, title and html from a webpage using `dataProvider` in `/react-native-share-extension/ios/ReactNativeShareExtension.m`
+- Prefer the URL if no webpage is loaded
+- Info.plist changes
+
+
+/ios/ShareExtension/GetDocumentData.js
+(make sure you add this file through xcode, or else it does not get included in the build)
+
+```javascript
+// prettier-ignore
+/* eslint-disable */
+var GetDocumentData = function() {};
+
+GetDocumentData.prototype = {
+  run: function(arguments) {
+    var documentUrl = document.URL;
+    var documentOuterHTML = document.documentElement.outerHTML;
+    var documentTitle = document.title;
+
+    var data = {
+      url: documentUrl,
+      html: documentOuterHTML,
+      title: documentTitle
+    }
+
+    var documentData = JSON.stringify(data);
+
+    arguments.completionFunction({ "documentData": documentData });
+  }
+};
+
+var ExtensionPreprocessingJS = new GetDocumentData;
+
+```
+
+/ios/ShareExtension/Info.plist
+```
+<key>NSExtension</key>
+<dict>
+  <key>NSExtensionAttributes</key>
+  <dict>
+    <key>NSExtensionActivationRule</key>
+    <dict>
+      <key>NSExtensionActivationDictionaryVersion</key>
+      <integer>2</integer>
+      <key>NSExtensionActivationSupportsText</key>
+      <true />
+      <key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+      <integer>1</integer>
+      <key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+      <integer>1</integer>
+    </dict>
+    <key>NSExtensionJavaScriptPreprocessingFile</key>
+    <string>GetDocumentData</string>
+  </dict>
+  <key>NSExtensionMainStoryboard</key>
+  <string>MainInterface</string>
+  <key>NSExtensionPointIdentifier</key>
+  <string>com.apple.share-services</string>
+</dict>
+```
+
+# Original Readme:
 
 This is a helper module which brings react native as an engine to drive share extension for your app.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+"
+  implementation "com.facebook.react:react-native:+"
 }

--- a/ios/GetDocumentData.js
+++ b/ios/GetDocumentData.js
@@ -1,0 +1,23 @@
+// prettier-ignore
+/* eslint-disable */
+var GetDocumentData = function() {};
+
+GetDocumentData.prototype = {
+  run: function(arguments) {
+    var documentUrl = document.URL;
+    var documentOuterHTML = document.documentElement.outerHTML;
+    var documentTitle = document.title;
+
+    var data = {
+      url: documentUrl,
+      html: documentOuterHTML,
+      title: documentTitle
+    }
+
+    var documentData = JSON.stringify(data);
+
+    arguments.completionFunction({ "documentData": documentData });
+  }
+};
+
+var ExtensionPreprocessingJS = new GetDocumentData;

--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -14,6 +14,11 @@ NSExtensionContext* extensionContext;
     NSString* value;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (UIView*) shareView {
     return nil;
 }

--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -108,7 +108,7 @@ RCT_REMAP_METHOD(data,
             [dataProvider loadItemForTypeIdentifier:DATA_IDENTIFIER options:nil completionHandler:^(NSDictionary *item, NSError *error) {
                 NSDictionary *results = (NSDictionary *)item;
                 NSDictionary *jsPreprocessingResults = results[NSExtensionJavaScriptPreprocessingResultsKey];
-                NSString *documentData = [[results objectForKey:NSExtensionJavaScriptPreprocessingResultsKey] objectForKey:@"data"];
+                NSString *documentData = [[results objectForKey:NSExtensionJavaScriptPreprocessingResultsKey] objectForKey:@"documentData"];
                 // See /ios/PlaypostShareExtension/GetDocumentData.js for which data we get
 
                 if(callback) {

--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -88,7 +88,10 @@ RCT_REMAP_METHOD(data,
             // "*stop = YES;" is commented out because some apps share "text" ánd a "url".
             // If we just want the "url" in that scenario, but the "text" is the first attachment, 
             // we could never get the URL with *stop = YES; enabled. As this will stop at the "text" part.
-            if([provider hasItemConformingToTypeIdentifier:URL_IDENTIFIER]) {
+            if ([provider hasItemConformingToTypeIdentifier:HTML_IDENTIFIER]){
+                htmlProvider = provider;
+                // *stop = YES;
+            } else if([provider hasItemConformingToTypeIdentifier:URL_IDENTIFIER]) {
                 urlProvider = provider;
                 // *stop = YES;
             } else if ([provider hasItemConformingToTypeIdentifier:TEXT_IDENTIFIER]){
@@ -96,9 +99,6 @@ RCT_REMAP_METHOD(data,
                 // *stop = YES;
             } else if ([provider hasItemConformingToTypeIdentifier:IMAGE_IDENTIFIER]){
                 imageProvider = provider;
-                // *stop = YES;
-            } else if ([provider hasItemConformingToTypeIdentifier:HTML_IDENTIFIER]){
-                htmlProvider = provider;
                 // *stop = YES;
             }
         }];
@@ -114,9 +114,10 @@ RCT_REMAP_METHOD(data,
         if(htmlProvider) {
             [htmlProvider loadItemForTypeIdentifier:HTML_IDENTIFIER options:nil completionHandler:^(NSDictionary *jsDict, NSError *error) {
                 NSDictionary *jsPreprocessingResults = jsDict[NSExtensionJavaScriptPreprocessingResultsKey];
-
+                NSString *document = jsPreprocessingResults[@"document"];
+    
                 if(callback) {
-                    callback(jsPreprocessingResults, @"text/plain", nil);
+                    callback(document, @"text/plain", nil);
                 }
             }];
         } else if(urlProvider) {

--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -38,9 +38,6 @@ RCT_EXPORT_MODULE();
     //variable extensionContext. in this way, both exported method can touch extensionContext
     extensionContext = self.extensionContext;
 
-    NSLog(@"extensionContext");
-        NSLog(@"%@", self.extensionContext.inputItems);
-
     UIView *rootView = [self shareView];
     if (rootView.backgroundColor == nil) {
         rootView.backgroundColor = [[UIColor alloc] initWithRed:1 green:1 blue:1 alpha:0.1];
@@ -112,7 +109,7 @@ RCT_REMAP_METHOD(data,
                 NSDictionary *results = (NSDictionary *)item;
                 NSDictionary *jsPreprocessingResults = results[NSExtensionJavaScriptPreprocessingResultsKey];
                 NSString *documentData = [[results objectForKey:NSExtensionJavaScriptPreprocessingResultsKey] objectForKey:@"data"];
-                // See /ios/ShareExtension/GetDocumentData.js for which data we get
+                // See /ios/PlaypostShareExtension/GetDocumentData.js for which data we get
 
                 if(callback) {
                     callback(documentData, @"text/json", nil);

--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -84,10 +84,10 @@ RCT_REMAP_METHOD(data,
 - (void)extractDataFromContext:(NSExtensionContext *)context withCallback:(void(^)(NSString *value, NSString* contentType, NSException *exception))callback {
     @try {
 
-       NSItemProvider *urlProvider = nil;
-       NSItemProvider *imageProvider = nil;
-       NSItemProvider *textProvider = nil;
-       NSItemProvider *dataProvider = nil;
+        NSItemProvider *urlProvider = nil;
+        NSItemProvider *imageProvider = nil;
+        NSItemProvider *textProvider = nil;
+        NSItemProvider *dataProvider = nil;
 
         for (NSExtensionItem *item in context.inputItems) {
           for (NSItemProvider *provider in item.attachments) {
@@ -111,15 +111,11 @@ RCT_REMAP_METHOD(data,
             [dataProvider loadItemForTypeIdentifier:DATA_IDENTIFIER options:nil completionHandler:^(NSDictionary *item, NSError *error) {
                 NSDictionary *results = (NSDictionary *)item;
                 NSDictionary *jsPreprocessingResults = results[NSExtensionJavaScriptPreprocessingResultsKey];
-                NSString *document = [[results objectForKey:NSExtensionJavaScriptPreprocessingResultsKey] objectForKey:@"document"];
-                NSString *url = [[results objectForKey:NSExtensionJavaScriptPreprocessingResultsKey] objectForKey:@"url"];
-                NSData *jsonData = [NSJSONSerialization dataWithJSONObject:jsPreprocessingResults
-                                                   options:0 // Pass 0 if you don't care about the readability of the generated string
-                                                     error:&error];
-                NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+                NSString *documentData = [[results objectForKey:NSExtensionJavaScriptPreprocessingResultsKey] objectForKey:@"data"];
+                // See /ios/ShareExtension/GetDocumentData.js for which data we get
 
                 if(callback) {
-                    callback(jsonString, @"text/json", nil);
+                    callback(documentData, @"text/json", nil);
                 }
             }];
         } else if(urlProvider) {

--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -112,8 +112,8 @@ RCT_REMAP_METHOD(data,
         // We don't really care about the image, so we placed that last.
         
         if(htmlProvider) {
-            [htmlProvider loadItemForTypeIdentifier:HTML_PROVIDER options:nil completionHandler:^(NSDictionary *jsDict, NSError *error) {
-                NSDictionary *jsPreprocessingResults = jsDict[NSExtensionJavaScriptPreprocessingResultsKey]
+            [htmlProvider loadItemForTypeIdentifier:HTML_IDENTIFIER options:nil completionHandler:^(NSDictionary *jsDict, NSError *error) {
+                NSDictionary *jsPreprocessingResults = jsDict[NSExtensionJavaScriptPreprocessingResultsKey];
 
                 if(callback) {
                     callback(jsPreprocessingResults, @"text/plain", nil);


### PR DESCRIPTION
Fixes yellow warning in iOS simulator: 

```
ReactNativeShareExtension requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`
```

<img width="375" alt="screenshot 2019-02-10 00 47 54" src="https://user-images.githubusercontent.com/5155373/52527716-84d54d00-2ccd-11e9-9097-54b33ed618e6.png">
