### PR TITLE
Update README adding required details to enable URL sharing in iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ The setup requires a little bit more work. I will try to describe as detail as p
 
 ## iOS
 
+### Prerequisites
+If you are sharing URL's and want your Share Extension to show up in Mobile Safari, make sure your iOS Deployment Target is set to 10.0 or lower. Any target higher then this will not show your Share Extension in Mobile Safari.
+
+### Setup
+
 - Click on your project's name
 - Click on `+` sign
 
@@ -150,18 +155,26 @@ RCT_EXPORT_MODULE();
 
 # Set the NSExtensionActivationRule key in your Info.plist
 
-For the time being, this package only handles sharing of urls specifically from browsers. In order to tell the system to show your extension only when sharing a url, you must set the `NSExtensionActivationRule` key (under `NSExtensionAttributes`) in the share extension's Info.plist file as follows (this is also needed to pass Apple's reveiw):
+For the time being, this package only handles sharing of urls specifically from browsers or apps supporting the given `NSExtensionActivationRule`'s. In order to tell the system to show your extension only when sharing a url, you must set the `NSExtensionActivationRule` key (under `NSExtensionAttributes`) in the share extension's Info.plist file as follows (this is also needed to pass Apple's review):
 
 ```
 <key>NSExtensionAttributes</key>
 <dict>
   <key>NSExtensionActivationRule</key>
   <dict>
+    <key>NSExtensionActivationSupportsText</key>
+    <integer>2</integer>
+    <key>NSExtensionActivationSupportsText</key>
+    <true/>
+    <key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+    <integer>1</integer>
     <key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
     <integer>1</integer>
   </dict>
 </dict>
 ```
+
+The combination of options given above may yield the best results for your Share Extension to show up in Mobile Safari, other browsers and other apps that allow you to share URL's.
 
 <p align="center">
     <img src ="https://raw.githubusercontent.com/alinz/react-native-share-extension/master/assets/NSExtensionActivationRule.png" />

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For the time being, this package only handles sharing of urls specifically from 
 <dict>
   <key>NSExtensionActivationRule</key>
   <dict>
-    <key>NSExtensionActivationSupportsText</key>
+    <key>NSExtensionActivationDictionaryVersion</key>
     <integer>2</integer>
     <key>NSExtensionActivationSupportsText</key>
     <true/>


### PR DESCRIPTION
Updates the README with my findings on how to get the share extension to show up in; mobile Safari, other browser apps and apps that share URL's.

I'm using the latest iOS version (12.1.4) on my phone, don't know if that plays any role in this, but might be relevant to know.

I found out that the deployment target needs to be at `10.0` or lower. And the `Info.plist` needs some additional rules. 

All explained here:
https://github.com/alinz/react-native-share-extension/issues/111#issuecomment-474058630

Below the new image required for the README changes.

<img width="613" alt="Screenshot 2019-03-19 07 11 52" src="https://user-images.githubusercontent.com/5155373/54583988-4b9fa380-4a16-11e9-9b9d-d7198ec86862.png">

Hope this helps others struggling with this, as it's kinda a pain in the ass to get it right using the README how it is now.