### PR TITLE
Fixes "WARNING: Configuration 'compile' is obsolete"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+"
+  implementation "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
Fixes the warning below when building the Android version:

```
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end oaf 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
Affected Modules: react-native-share-extension
```