### PR TITLE
Fix overriding with weaker access privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
-    protected boolean getUseDeveloperSupport() {
+    public boolean getUseDeveloperSupport() {
       return BuildConfig.DEBUG;
     }
 


### PR DESCRIPTION
When using the tutorial to set up rn-share-extension, I got the following error:
`cannot override getUseDeveloperSupport() in ReactNativeHost`
`attempting to assign weaker access privileges; was public`

This PR fixes this error.