### PR TITLE
Use original file name and extension for image URLs

### DIFF
--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -68,7 +68,6 @@ RCT_REMAP_METHOD(data,
 }
 
 - (void)extractDataFromContext:(NSExtensionContext *)context withCallback:(void(^)(NSString *value, NSString* contentType, NSException *exception))callback {
-    
     @try {
         NSExtensionItem *item = [context.inputItems firstObject];
         NSArray *attachments = item.attachments;
@@ -108,15 +107,17 @@ RCT_REMAP_METHOD(data,
                  * Therefore the solution is to save a UIImage, either way, and return the local path to that temp UIImage
                  * This path will be sent to React Native and can be processed and accessed RN side.
                 **/
-                
+
                 UIImage *sharedImage;
-                NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"RNSE_TEMP_IMG"];
-                NSString *fullPath = [filePath stringByAppendingPathExtension:@"png"];
-                
+                NSString *filePath = nil;
+                NSString *fullPath = nil;
+
                 if ([(NSObject *)item isKindOfClass:[UIImage class]]){
                     sharedImage = (UIImage *)item;
+                    fullPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"Image.png"];
                 }else if ([(NSObject *)item isKindOfClass:[NSURL class]]){
                     NSURL* url = (NSURL *)item;
+                    fullPath = [NSTemporaryDirectory() stringByAppendingPathComponent:url.lastPathComponent];
                     NSData *data = [NSData dataWithContentsOfURL:url];
                     sharedImage = [UIImage imageWithData:data];
                 }
@@ -147,7 +148,5 @@ RCT_REMAP_METHOD(data,
         }
     }
 }
-
-
 
 @end

--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -68,6 +68,7 @@ RCT_REMAP_METHOD(data,
 }
 
 - (void)extractDataFromContext:(NSExtensionContext *)context withCallback:(void(^)(NSString *value, NSString* contentType, NSException *exception))callback {
+    
     @try {
         NSExtensionItem *item = [context.inputItems firstObject];
         NSArray *attachments = item.attachments;
@@ -99,10 +100,31 @@ RCT_REMAP_METHOD(data,
             }];
         } else if (imageProvider) {
             [imageProvider loadItemForTypeIdentifier:IMAGE_IDENTIFIER options:nil completionHandler:^(id<NSSecureCoding> item, NSError *error) {
-                NSURL *url = (NSURL *)item;
-
+                
+                /**
+                 * Save the image to NSTemporaryDirectory(), which cleans itself tri-daily.
+                 * This is necessary as the iOS 11 screenshot editor gives us a UIImage, while
+                 * sharing from Photos and similar apps gives us a URL
+                 * Therefore the solution is to save a UIImage, either way, and return the local path to that temp UIImage
+                 * This path will be sent to React Native and can be processed and accessed RN side.
+                **/
+                
+                UIImage *sharedImage;
+                NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"RNSE_TEMP_IMG"];
+                NSString *fullPath = [filePath stringByAppendingPathExtension:@"png"];
+                
+                if ([(NSObject *)item isKindOfClass:[UIImage class]]){
+                    sharedImage = (UIImage *)item;
+                }else if ([(NSObject *)item isKindOfClass:[NSURL class]]){
+                    NSURL* url = (NSURL *)item;
+                    NSData *data = [NSData dataWithContentsOfURL:url];
+                    sharedImage = [UIImage imageWithData:data];
+                }
+                
+                [UIImagePNGRepresentation(sharedImage) writeToFile:fullPath atomically:YES];
+                
                 if(callback) {
-                    callback([url absoluteString], [[[url absoluteString] pathExtension] lowercaseString], nil);
+                    callback(fullPath, [fullPath pathExtension], nil);
                 }
             }];
         } else if (textProvider) {
@@ -125,5 +147,7 @@ RCT_REMAP_METHOD(data,
         }
     }
 }
+
+
 
 @end


### PR DESCRIPTION
This is the implementation of my proposed comment https://github.com/alinz/react-native-share-extension/pull/132#issuecomment-501552285

This will save the fetch URL image in a temp directory with the original name and extension.